### PR TITLE
Fix failed output -- restore original functionality.

### DIFF
--- a/app_specs/FastqUtils.json
+++ b/app_specs/FastqUtils.json
@@ -3,7 +3,9 @@
   "label": "Fastq Utilites",
   "script": "App-FastqUtils",
   "description": "Useful common processing of fastq files",
-  "default_memory": "100G",
+    "default_memory": "10G",
+    "default_cpu": 2,
+    "default_runtime": 36000,
   "parameters": [
     {
         "id": "reference_genome_id",

--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -431,7 +431,6 @@ def setup(job_data, output_dir, tool_params):
                         elif f.endswith("fastqc.html"):
                             r["fastqc"].append(os.path.join(target_dir, f))
     recipe = job_data.get("recipe", [])
-    read_list = paired_filter(read_list, tool_params, output_dir, job_data)
     return genome_list, read_list, recipe
 
 
@@ -451,7 +450,11 @@ def run_fq_util(job_data, output_dir, tool_params={}):
         if step == "TRIM":
             trimmed_reads = run_trim(read_list, output_dir, job_data, tool_params)
             read_list = trimmed_reads
-        if step == "FASTQC":
+        elif step == "PAIRED_FILTER":
+            read_list = paired_filter(read_list, tool_params, output_dir, job_data)
+        elif step == "FASTQC":
             run_fastqc(read_list, output_dir, job_data, tool_params)
-        if step == "ALIGN":
+        elif step == "ALIGN":
             run_alignment(genome_list, read_list, tool_params, output_dir, job_data)
+        else:
+            print("Skipping step. Not found: {}".format(step), file=sys.stderr)

--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -315,6 +315,24 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
             subprocess.call(["rm", garbage])
 
 
+def paired_filter(read_list, parameters, output_dir, job_data):
+    def unzip(path):
+        if path.endswith(".gz"):
+            subprocess.call(["gunzip", path])
+            return path[0 : len(path) - 3]
+        return path
+
+    for r in read_list:
+        if "read2" in r:
+            r["read1"] = unzip(unzip(r["read1"]))
+            r["read2"] = unzip(unzip(r["read2"]))
+            pair_cmd = ["fastq_pair", r["read1"], r["read2"]]
+            subprocess.call(pair_cmd)
+            r["read1"] += "paired.fq"
+            r["read2"] += "paired.fq"
+    return read_list
+
+
 def get_genome(parameters, host_manifest={}):
     target_file = os.path.join(parameters["output_path"], parameters["gid"] + ".fna")
     print("GID: {}".format(parameters["gid"]), file=sys.stderr)
@@ -328,8 +346,10 @@ def get_genome(parameters, host_manifest={}):
                     shutil.copyfileobj(r, f)
         else:
             # parameters["data_api"], parameters["gid"])
-            genome_url = "{data_api}/genome_sequence/?eq(genome_id,{gid})&limit(25000)".format(
-                **parameters
+            genome_url = (
+                "{data_api}/genome_sequence/?eq(genome_id,{gid})&limit(25000)".format(
+                    **parameters
+                )
             )
             headers = {"accept": "application/sralign+dna+fasta"}
             req = requests.Request("GET", genome_url, headers=headers)
@@ -411,6 +431,7 @@ def setup(job_data, output_dir, tool_params):
                         elif f.endswith("fastqc.html"):
                             r["fastqc"].append(os.path.join(target_dir, f))
     recipe = job_data.get("recipe", [])
+    read_list = paired_filter(read_list, tool_params, output_dir, job_data)
     return genome_list, read_list, recipe
 
 

--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -228,6 +228,7 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
             cur_cleanup.append(sam_file)
             bam_file_all = sam_file[:-4] + ".all.bam"
             bam_file_aligned = sam_file[:-4] + ".aligned.bam"
+            bam_file_sort_name = sam_file[:-4] + ".aligned.name.bam"
             fastq_file_aligned = sam_file[:-4] + ".aligned.fq"
             # fastq_file_aligned1 = sam_file[:-4] + ".aligned.1.fq"
             fastq_file_aligned2 = sam_file[:-4] + ".aligned.2.fq"
@@ -266,11 +267,18 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
                     shell=True,
                     check=True,
                 )
+                sort_name_cmd = [
+                    "samtools",
+                    "sort",
+                    "-n",
+                    bam_file_aligned,
+                    bam_file_sort_name,
+                ]
                 bam2fq_cmd = [
                     "bedtools",
                     "bamtofastq",
                     "-i",
-                    bam_file_aligned,
+                    bam_file_sort_name,
                     "-fq",
                     fastq_file_aligned,
                 ]
@@ -279,6 +287,9 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
                 if read2:  # paired end
                     bam2fq_cmd += ["-fq2", fastq_file_aligned2]
                     bam2fqgz_cmd += [fastq_file_aligned2]
+                print(" ".join(sort_name_cmd))
+                # Need to sort by name to convert to fastq: samtools sort -n myBamFile.bam myBamFile.sortedByName
+                subprocess.run(sort_name_cmd, check=True)
                 print((" ".join(bam2fq_cmd)))
                 subprocess.run(bam2fq_cmd, check=True)
                 subprocess.run(bam2fqgz_cmd, check=True)

--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -322,14 +322,15 @@ def paired_filter(read_list, parameters, output_dir, job_data):
             return path[0 : len(path) - 3]
         return path
 
+    print("Running paired filter.")
     for r in read_list:
         if "read2" in r:
             r["read1"] = unzip(unzip(r["read1"]))
             r["read2"] = unzip(unzip(r["read2"]))
             pair_cmd = ["fastq_pair", r["read1"], r["read2"]]
             subprocess.call(pair_cmd)
-            r["read1"] += "paired.fq"
-            r["read2"] += "paired.fq"
+            r["read1"] += ".paired.fq"
+            r["read2"] += ".paired.fq"
     return read_list
 
 

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -50,14 +50,16 @@ sub preflight
 
     my $est_uncomp = $comp_size / 0.75 + $uncomp_size;
 
-    my $est_time = int($est_uncomp * 1e-6);
+    my $est_time = int($est_uncomp * 1e-6 * 1.5);
 
-    #
-    # We just fix the cpu and ram
-    #
     my $est_cpu = 2;
+    my $est_ram = '32G';
 
-    my $est_ram = $est_time > 3600 ? '128G' : '32G';
+    if ($est_time > 3600)
+    {
+	$est_ram = '128G';
+	$est_cpu = 8;
+    }
 
     return {
 	cpu => $est_cpu,

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -174,18 +174,19 @@ sub process_fastq
 
     warn Dumper(\@cmd, $params_to_app);
 
-    my $ok = run(\@cmd,
-		 ">", "$work_dir/fqutils.out.txt",
-		 "2>", "$work_dir/fqutils.err.txt");
+    my $ok = run(\@cmd);
+    # my $ok = run(\@cmd,
+	# 	 ">", "$work_dir/fqutils.out.txt",
+	# 	 "2>", "$work_dir/fqutils.err.txt");
     if (!$ok)
     {
-        opendir(D, $work_dir) or die "Cannot opendir $work_dir: $!";
-        $app->workspace->save_file_to_file("$work_dir/fqutils.out.txt", {}, "$output_folder/fqutils.out.txt", "txt", 1,
-                            (-s "$work_dir/fqutils.out.txt" > 10_000 ? 1 : 0), # use shock for larger files
-                            $token);
-        $app->workspace->save_file_to_file("$work_dir/fqutils.err.txt", {}, "$output_folder/fqutils.err.txt", "txt", 1,
-        (-s "$work_dir/fqutils.err.txt" > 10_000 ? 1 : 0), # use shock for larger files
-        $token);
+        # opendir(D, $work_dir) or die "Cannot opendir $work_dir: $!";
+        # $app->workspace->save_file_to_file("$work_dir/fqutils.out.txt", {}, "$output_folder/fqutils.out.txt", "txt", 1,
+        #                     (-s "$work_dir/fqutils.out.txt" > 10_000 ? 1 : 0), # use shock for larger files
+        #                     $token);
+        # $app->workspace->save_file_to_file("$work_dir/fqutils.err.txt", {}, "$output_folder/fqutils.err.txt", "txt", 1,
+        # (-s "$work_dir/fqutils.err.txt" > 10_000 ? 1 : 0), # use shock for larger files
+        # $token);
 	    die "Command failed: @cmd\n";
     }
 

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -52,13 +52,12 @@ sub preflight
 
     my $est_time = int($est_uncomp * 1e-6 * 1.5);
 
-    my $est_cpu = 2;
+    my $est_cpu = 8;
     my $est_ram = '32G';
 
     if ($est_time > 3600)
     {
 	$est_ram = '128G';
-	$est_cpu = 8;
     }
 
     return {

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -163,7 +163,8 @@ sub process_fastq
 	bowtie2 => {-p => $parallel},
 	hisat2 => {-p => $parallel},
 	samtools_view => {-p => $parallel},
-	samtools_index => {-p => $parallel}
+	samtools_index => {-p => $parallel},
+    samtools_sort => {-p => $parallel}
     };
 
     my @cmd = ("p3-fqutils",

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -166,7 +166,13 @@ sub process_fastq
 	samtools_index => {-p => $parallel}
     };
 
-    my @cmd = ("p3-fqutils", "--jfile", $jdesc, "--sstring", $sstring, "-p", encode_json($override), "-o", $work_dir);
+    my @cmd = ("p3-fqutils",
+	       "--jfile", $jdesc,
+	       "--sstring", $sstring,
+	       "-p", encode_json($override),
+	       "-o", $work_dir,
+	       ">", "$work_dir/fqutils.out.txt",
+	       "2>", "$work_dir/fqutils.err.txt");
 
     warn Dumper(\@cmd, $params_to_app);
     

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -170,13 +170,13 @@ sub process_fastq
 	       "--jfile", $jdesc,
 	       "--sstring", $sstring,
 	       "-p", encode_json($override),
-	       "-o", $work_dir,
-	       ">", "$work_dir/fqutils.out.txt",
-	       "2>", "$work_dir/fqutils.err.txt");
+	       "-o", $work_dir);
 
     warn Dumper(\@cmd, $params_to_app);
     
-    my $ok = run(\@cmd);
+    my $ok = run(\@cmd,
+		 ">", "$work_dir/fqutils.out.txt",
+		 "2>", "$work_dir/fqutils.err.txt");
     if (!$ok)
     {
 	die "Command failed: @cmd\n";

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -50,12 +50,16 @@ sub preflight
 
     my $est_uncomp = $comp_size / 0.75 + $uncomp_size;
 
-    my $est_time = int($est_uncomp * 1e-6 * 1.5);
+    my $est_time = int($est_uncomp * 1e-6 * 3.0);
 
     my $est_cpu = 8;
     my $est_ram = '32G';
 
-    if ($est_time > 3600)
+    if ($est_time < 3600)
+    {
+	$est_time = 3600;
+    }
+    elsif ($est_time > 3600 * 2)
     {
 	$est_ram = '128G';
     }

--- a/test/align_output.json
+++ b/test/align_output.json
@@ -1,0 +1,14 @@
+{
+    "output_path": "/jsporter@patricbrc.org/home/Test_Files",
+    "output_file": "fqutils_output",
+    "reference_genome_id": "93061.5",
+    "paired_end_libs": [
+        {
+                    "read1": "/jsporter@patricbrc.org/home/Test_Files/331_S13_L001_R1_001.fastq",
+                    "read2": "/jsporter@patricbrc.org/home/Test_Files/331_S13_L001_R2_001.fastq"
+                }
+    ],
+    "recipe": [
+        "Align"
+    ]
+}

--- a/test/fastq_filter.json
+++ b/test/fastq_filter.json
@@ -1,0 +1,13 @@
+{
+    "output_path": "/jsporter@patricbrc.org/home/Test_Files",
+    "output_file": "fqutils_filter",
+    "paired_end_libs": [
+        {
+	            "read1": "/jsporter@patricbrc.org/home/Test_Files/SRR10961160_1.fastq",
+	            "read2": "/jsporter@patricbrc.org/home/Test_Files/SRR10961160_2.fastq"
+	        }
+    ],
+    "recipe": [
+        "Paired_Filter"
+    ]
+}

--- a/test/fastq_filter_align.json
+++ b/test/fastq_filter_align.json
@@ -1,0 +1,15 @@
+{
+    "output_path": "/jsporter@patricbrc.org/home/Test_Files",
+    "output_file": "fqutils_filter_align",
+    "reference_genome_id": "1100842.3",
+    "paired_end_libs": [
+        {
+	            "read1": "/jsporter@patricbrc.org/home/Test_Files/bau_sim_R1.fq",
+	            "read2": "/jsporter@patricbrc.org/home/Test_Files/bau_sim_R2.fq"
+	        }
+    ],
+    "recipe": [
+        "Paired_Filter",
+        "Align"
+    ]
+}

--- a/test/fastq_filter_gz.json
+++ b/test/fastq_filter_gz.json
@@ -1,0 +1,15 @@
+{
+    "output_path": "/jsporter@patricbrc.org/home/Test_Files",
+    "output_file": "fastq_filter_gz",
+    "reference_genome_id": "903917.3",
+    "paired_end_libs": [
+        {
+	            "read1": "/jsporter@patricbrc.org/home/Test_Files/bau_sim_R1.fq.gz",
+	            "read2": "/jsporter@patricbrc.org/home/Test_Files/bau_sim_R2.fq.gz"
+	        }
+    ],
+    "recipe": [
+        "Paired_Filter",
+        "Align"
+    ]
+}


### PR DESCRIPTION
Restores original stderr and stdout functionality so that it is available when the job fails.
Redirects bedtools stderr to a log file.
Sorts bam files before converting to a fasta file.